### PR TITLE
feat(config): add analyzers configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# semverbump
+
+Static public-API diff and heuristics to suggest semantic version bumps.
+
+## Configuration
+
+Create a `semverbump.toml` file to customize behavior.
+
+### Analyzers
+
+Optional analyzers can be enabled in the `[analyzers]` section. Each key is the
+name of an analyzer plugin with a boolean flag indicating whether it should run.
+
+```toml
+[analyzers]
+flask_routes = true
+sqlalchemy = true
+```
+
+Only analyzers explicitly set to `true` are enabled.

--- a/semverbump/config.py
+++ b/semverbump/config.py
@@ -1,42 +1,88 @@
 from __future__ import annotations
+
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Set
-import tomllib
 
 _DEFAULTS = {
     "project": {"package": "", "public_roots": ["."], "index_file": "pyproject.toml"},
     "ignore": {"paths": ["tests/**", "examples/**", "scripts/**"]},
     "rules": {"return_type_change": "minor"},  # or "major"
+    "analyzers": {},
 }
+
 
 @dataclass
 class Rules:
+    """Rules controlling version bump decisions."""
+
     return_type_change: str = "minor"  # "minor" | "major"
+
 
 @dataclass
 class Project:
+    """Project metadata and locations."""
+
     package: str = ""
     public_roots: List[str] = field(default_factory=lambda: ["."])
     index_file: str = "pyproject.toml"
 
+
 @dataclass
 class Ignore:
-    paths: List[str] = field(default_factory=lambda: ["tests/**", "examples/**", "scripts/**"])
+    """Paths to ignore during scanning."""
+
+    paths: List[str] = field(
+        default_factory=lambda: ["tests/**", "examples/**", "scripts/**"]
+    )
+
+
+@dataclass
+class Analyzers:
+    """Analyzer plugin configuration.
+
+    Attributes:
+        enabled: Names of enabled analyzer plugins.
+    """
+
+    enabled: Set[str] = field(default_factory=set)
+
 
 @dataclass
 class Config:
+    """Top-level configuration for semverbump.
+
+    Attributes:
+        project: Project settings.
+        rules: Rules controlling version bumps.
+        ignore: Paths to exclude when scanning.
+        analyzers: Optional analyzer plugin settings.
+    """
+
     project: Project = field(default_factory=Project)
     rules: Rules = field(default_factory=Rules)
     ignore: Ignore = field(default_factory=Ignore)
+    analyzers: Analyzers = field(default_factory=Analyzers)
+
 
 def _merge_defaults(data: dict) -> dict:
+    """Merge user data with default configuration."""
     out = {k: dict(v) for k, v in _DEFAULTS.items()}
     for section, content in (data or {}).items():
         out.setdefault(section, {}).update(content or {})
     return out
 
+
 def load_config(path: str | Path = "semverbump.toml") -> Config:
+    """Load configuration from a TOML file.
+
+    Args:
+        path: Path to the configuration file.
+
+    Returns:
+        Parsed configuration object.
+    """
     p = Path(path)
     if not p.exists():
         d = _merge_defaults({})
@@ -45,4 +91,6 @@ def load_config(path: str | Path = "semverbump.toml") -> Config:
     proj = Project(**d["project"])
     rules = Rules(**d["rules"])
     ign = Ignore(**d["ignore"])
-    return Config(project=proj, rules=rules, ignore=ign)
+    enabled = {name for name, enabled in d["analyzers"].items() if enabled}
+    analyzers = Analyzers(enabled=enabled)
+    return Config(project=proj, rules=rules, ignore=ign, analyzers=analyzers)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,13 @@
+from semverbump.config import load_config
+
+
+def test_load_config_parses_analyzers(tmp_path):
+    cfg_file = tmp_path / "semverbump.toml"
+    cfg_file.write_text("[analyzers]\nflask_routes = true\nsqlalchemy = false\n")
+    cfg = load_config(cfg_file)
+    assert cfg.analyzers.enabled == {"flask_routes"}
+
+
+def test_load_config_defaults_analyzers(tmp_path):
+    cfg = load_config(tmp_path / "missing.toml")
+    assert cfg.analyzers.enabled == set()


### PR DESCRIPTION
## Summary
- add `analyzers` section and dataclass to track enabled analyzer plugins
- parse `[analyzers]` from `semverbump.toml`
- document enabling analyzers in config

## Testing
- `ruff check semverbump/config.py tests/test_config.py`
- `isort semverbump/config.py tests/test_config.py`
- `black semverbump/config.py tests/test_config.py`
- `pytest` *(fails: CSTCodegenError: Must specify a concrete default_indicator if default used on indicator.)*

------
https://chatgpt.com/codex/tasks/task_e_689ee0325608832286ed121c0d16a073