### PR TITLE
feat(cli-analyzer): analyze command-line interface changes

### DIFF
--- a/semverbump/analyzers/__init__.py
+++ b/semverbump/analyzers/__init__.py
@@ -1,0 +1,3 @@
+"""Analyzer plugin package for semverbump."""
+
+__all__ = ["cli"]

--- a/semverbump/analyzers/cli.py
+++ b/semverbump/analyzers/cli.py
@@ -1,0 +1,200 @@
+"""CLI analyzer for detecting interface changes.
+
+This module introspects ``argparse`` and ``click`` command definitions to
+produce a simple representation of a command line interface. The resulting
+representation can be diffed between two versions to determine the semantic
+version impact of CLI changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from ..compare import Impact
+from ..gitutils import read_file_at_ref
+
+try:
+    import click  # type: ignore
+except Exception:  # pragma: no cover - click optional
+    click = None  # type: ignore
+
+
+@dataclass
+class CommandSpec:
+    """Description of a single command.
+
+    Attributes:
+        options: Mapping of option/argument name to a boolean indicating
+            whether it is required.
+    """
+
+    options: Dict[str, bool]
+
+
+CLI = Dict[str, CommandSpec]
+
+
+def _extract_argparse(parser: argparse.ArgumentParser, prefix: str = "") -> CLI:
+    """Extract command specifications from an ``argparse`` parser.
+
+    Args:
+        parser: Parser to inspect.
+        prefix: Command path accumulated during recursion.
+
+    Returns:
+        Mapping of command paths to their specifications.
+    """
+
+    result: CLI = {}
+    opts: Dict[str, bool] = {}
+    for action in parser._actions:  # type: ignore[attr-defined]
+        if isinstance(action, argparse._SubParsersAction):  # type: ignore[attr-defined]
+            for name, sub in action.choices.items():
+                new_prefix = f"{prefix} {name}".strip()
+                result.update(_extract_argparse(sub, new_prefix))
+        else:
+            if action.dest == "help":
+                continue
+            required = getattr(action, "required", False)
+            if not action.option_strings:
+                required = True
+            opts[action.dest] = required
+    result[prefix] = CommandSpec(opts)
+    return result
+
+
+def _extract_click(cmd: "click.core.Command", prefix: str = "") -> CLI:  # type: ignore
+    """Extract command specifications from a ``click`` command object.
+
+    Args:
+        cmd: Click command or group to inspect.
+        prefix: Command path accumulated during recursion.
+
+    Returns:
+        Mapping of command paths to their specifications.
+    """
+
+    result: CLI = {}
+    opts = {p.name: p.required for p in getattr(cmd, "params", [])}
+    result[prefix] = CommandSpec(opts)
+    if isinstance(cmd, getattr(click, "Group", tuple())):
+        for name, sub in cmd.commands.items():
+            new_prefix = f"{prefix} {name}".strip()
+            result.update(_extract_click(sub, new_prefix))
+    return result
+
+
+def extract_cli(obj: Any) -> CLI:
+    """Create a CLI specification from ``argparse`` or ``click`` objects.
+
+    Args:
+        obj: ``argparse.ArgumentParser`` or ``click`` command/group.
+
+    Returns:
+        CLI specification mapping command paths to option requirements.
+    """
+
+    if isinstance(obj, argparse.ArgumentParser):
+        return _extract_argparse(obj)
+    if click and isinstance(obj, click.core.Command):  # type: ignore[attr-defined]
+        return _extract_click(obj)
+    return {}
+
+
+def diff_cli(old: CLI, new: CLI) -> List[Impact]:
+    """Diff two CLI specifications.
+
+    Args:
+        old: CLI specification from the base revision.
+        new: CLI specification from the head revision.
+
+    Returns:
+        List of impacts describing semantic version changes.
+    """
+
+    impacts: List[Impact] = []
+    old_cmds, new_cmds = set(old), set(new)
+    for cmd in old_cmds - new_cmds:
+        impacts.append(Impact("major", cmd or "<root>", "Removed command"))
+    for cmd in new_cmds - old_cmds:
+        impacts.append(Impact("minor", cmd or "<root>", "Added command"))
+    for cmd in old_cmds & new_cmds:
+        o, n = old[cmd].options, new[cmd].options
+        for opt in o.keys() - n.keys():
+            impacts.append(Impact("major", cmd or "<root>", f"Removed option '{opt}'"))
+        for opt in n.keys() - o.keys():
+            severity = "major" if n[opt] else "minor"
+            reason = "Added required option" if n[opt] else "Added optional option"
+            impacts.append(Impact(severity, cmd or "<root>", reason))
+        for opt in o.keys() & n.keys():
+            if o[opt] != n[opt]:
+                impacts.append(
+                    Impact(
+                        "major",
+                        cmd or "<root>",
+                        f"Option '{opt}' requirement changed",
+                    )
+                )
+    return impacts
+
+
+def _load_cli_from_source(src: str) -> CLI:
+    """Execute source code and extract CLI specification.
+
+    The code is executed in an isolated namespace.  A variable named ``parser``
+    or ``cli`` may define the CLI object.  If it is callable, it will be
+    invoked without arguments.
+
+    Args:
+        src: Python source defining the CLI.
+
+    Returns:
+        CLI specification, or an empty mapping if none found.
+    """
+
+    ns: Dict[str, Any] = {}
+    try:
+        exec(src, ns)
+    except Exception:
+        return {}
+    obj = ns.get("parser") or ns.get("cli")
+    if callable(obj):
+        obj = obj()
+    return extract_cli(obj) if obj is not None else {}
+
+
+def build_cli_at_ref(ref: str, package: str) -> CLI:
+    """Build CLI specification for a given git ref.
+
+    Args:
+        ref: Git reference to read from.
+        package: Package name where ``cli.py`` resides.
+
+    Returns:
+        CLI specification extracted from that ref.
+    """
+
+    path = f"{package}/cli.py" if package else "cli.py"
+    src = read_file_at_ref(ref, path)
+    if src is None:
+        return {}
+    return _load_cli_from_source(src)
+
+
+def diff_cli_at_refs(package: str, base: str, head: str) -> List[Impact]:
+    """Compute CLI impacts between two git references.
+
+    Args:
+        package: Package containing the CLI module.
+        base: Base git reference.
+        head: Head git reference.
+
+    Returns:
+        List of impacts derived from CLI differences.
+    """
+
+    old = build_cli_at_ref(base, package)
+    new = build_cli_at_ref(head, package)
+    return diff_cli(old, new)

--- a/semverbump/cli.py
+++ b/semverbump/cli.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
-import argparse, json, sys
-from pathlib import Path
-from typing import Dict, List
+
+import argparse
+import json
+import sys
+
+from .compare import decide_bump, diff_public_api
 from .config import load_config
 from .gitutils import list_py_files_at_ref, read_file_at_ref
-from .public_api import extract_public_api_from_source, module_name_from_path, PublicAPI
-from .compare import diff_public_api, decide_bump
+from .public_api import PublicAPI, extract_public_api_from_source, module_name_from_path
 from .versioning import apply_bump
+
 
 def _build_api_at_ref(ref: str, roots: list[str]) -> PublicAPI:
     api: PublicAPI = {}
@@ -20,25 +23,34 @@ def _build_api_at_ref(ref: str, roots: list[str]) -> PublicAPI:
             api.update(extract_public_api_from_source(modname, code))
     return api
 
+
 def _format_impacts_text(impacts) -> str:
     lines = []
     for i in impacts:
         lines.append(f"- [{i.severity.upper()}] {i.symbol}: {i.reason}")
     return "\n".join(lines) if lines else "(no API-impacting changes detected)"
 
+
 def decide_cmd(args) -> int:
     cfg = load_config(args.config)
     old_api = _build_api_at_ref(args.base, cfg.project.public_roots)
     new_api = _build_api_at_ref(args.head, cfg.project.public_roots)
 
-    impacts = diff_public_api(old_api, new_api, return_type_change=cfg.rules.return_type_change)
+    impacts = diff_public_api(
+        old_api, new_api, return_type_change=cfg.rules.return_type_change
+    )
+    if "cli" in cfg.analyzers.enabled:
+        from .analyzers.cli import diff_cli_at_refs
+
+        impacts.extend(diff_cli_at_refs(cfg.project.package, args.base, args.head))
     level = decide_bump(impacts)
 
     if args.format == "json":
-        print(json.dumps({
-            "level": level,
-            "impacts": [i.__dict__ for i in impacts]
-        }, indent=2))
+        print(
+            json.dumps(
+                {"level": level, "impacts": [i.__dict__ for i in impacts]}, indent=2
+            )
+        )
     elif args.format == "md":
         print(f"**semverbump** suggests: `{level}`\n")
         print(_format_impacts_text(impacts))
@@ -47,6 +59,7 @@ def decide_cmd(args) -> int:
         print(_format_impacts_text(impacts))
     return 0
 
+
 def bump_cmd(args) -> int:
     # If level not provided, compute from base/head
     level = args.level
@@ -54,45 +67,66 @@ def bump_cmd(args) -> int:
         cfg = load_config(args.config)
         old_api = _build_api_at_ref(args.base, cfg.project.public_roots)
         new_api = _build_api_at_ref(args.head, cfg.project.public_roots)
-        impacts = diff_public_api(old_api, new_api, return_type_change=cfg.rules.return_type_change)
+        impacts = diff_public_api(
+            old_api, new_api, return_type_change=cfg.rules.return_type_change
+        )
         level = decide_bump(impacts)
 
     vc = apply_bump(level, pyproject_path=args.pyproject)
     print(f"Bumped version: {vc.old} -> {vc.new} ({vc.level})")
     if args.commit or args.tag:
         import subprocess
+
         # Commit
         if args.commit:
             subprocess.run(["git", "add", args.pyproject], check=True)
-            subprocess.run(["git", "commit", "-m", f"chore(release): {vc.new}"], check=True)
+            subprocess.run(
+                ["git", "commit", "-m", f"chore(release): {vc.new}"], check=True
+            )
         # Tag
         if args.tag:
             subprocess.run(["git", "tag", f"v{vc.new}"], check=True)
     return 0
 
+
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="semverbump", description="Suggest and apply semantic version bumps.")
-    parser.add_argument("--config", default="semverbump.toml", help="Path to config (default: semverbump.toml)")
+    parser = argparse.ArgumentParser(
+        prog="semverbump", description="Suggest and apply semantic version bumps."
+    )
+    parser.add_argument(
+        "--config",
+        default="semverbump.toml",
+        help="Path to config (default: semverbump.toml)",
+    )
 
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     p_decide = sub.add_parser("decide", help="Suggest bump between two refs")
-    p_decide.add_argument("--base", required=True, help="Base ref (e.g., origin/master)")
+    p_decide.add_argument(
+        "--base", required=True, help="Base ref (e.g., origin/master)"
+    )
     p_decide.add_argument("--head", default="HEAD", help="Head ref (default: HEAD)")
     p_decide.add_argument("--format", choices=["text", "md", "json"], default="text")
     p_decide.set_defaults(func=decide_cmd)
 
     p_bump = sub.add_parser("bump", help="Apply a bump to pyproject.toml")
-    p_bump.add_argument("--level", choices=["major", "minor", "patch"], help="Bump level; if omitted, auto-decide from refs")
+    p_bump.add_argument(
+        "--level",
+        choices=["major", "minor", "patch"],
+        help="Bump level; if omitted, auto-decide from refs",
+    )
     p_bump.add_argument("--base", help="Base ref (for auto decide)")
     p_bump.add_argument("--head", default="HEAD", help="Head ref (for auto decide)")
     p_bump.add_argument("--pyproject", default="pyproject.toml")
-    p_bump.add_argument("--commit", action="store_true", help="git commit the version change")
+    p_bump.add_argument(
+        "--commit", action="store_true", help="git commit the version change"
+    )
     p_bump.add_argument("--tag", action="store_true", help="git tag the new version")
     p_bump.set_defaults(func=bump_cmd)
 
     args = parser.parse_args(argv)
     return args.func(args)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/semverbump/config.py
+++ b/semverbump/config.py
@@ -9,7 +9,7 @@ _DEFAULTS = {
     "project": {"package": "", "public_roots": ["."], "index_file": "pyproject.toml"},
     "ignore": {"paths": ["tests/**", "examples/**", "scripts/**"]},
     "rules": {"return_type_change": "minor"},  # or "major"
-    "analyzers": {},
+    "analyzers": {"cli": False},
 }
 
 

--- a/tests/test_cli_analyzer.py
+++ b/tests/test_cli_analyzer.py
@@ -1,0 +1,74 @@
+import argparse
+
+import click
+
+from semverbump.analyzers.cli import diff_cli, extract_cli
+
+
+def _argparse_v1() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    run = sub.add_parser("run")
+    run.add_argument("--force", action="store_true")
+    return parser
+
+
+def _argparse_v2_optional() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    run = sub.add_parser("run")
+    run.add_argument("--force", action="store_true")
+    run.add_argument("--verbose", action="store_true")
+    return parser
+
+
+def _argparse_v2_removed_cmd() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser()
+
+
+def _click_v1() -> click.Group:
+    @click.group()
+    def cli() -> None:
+        """Top level."""
+
+    @cli.command()
+    @click.option("--force", is_flag=True)
+    def build(force: bool) -> None:  # pragma: no cover - runtime check
+        pass
+
+    return cli
+
+
+def _click_v2_required() -> click.Group:
+    @click.group()
+    def cli() -> None:
+        """Top level."""
+
+    @cli.command()
+    @click.option("--force", is_flag=True)
+    @click.option("--config", required=True)
+    def build(force: bool, config: str) -> None:  # pragma: no cover - runtime check
+        pass
+
+    return cli
+
+
+def test_added_optional_flag_is_minor() -> None:
+    old = extract_cli(_argparse_v1())
+    new = extract_cli(_argparse_v2_optional())
+    impacts = diff_cli(old, new)
+    assert any(i.severity == "minor" for i in impacts)
+
+
+def test_removed_command_is_major() -> None:
+    old = extract_cli(_argparse_v1())
+    new = extract_cli(_argparse_v2_removed_cmd())
+    impacts = diff_cli(old, new)
+    assert any(i.severity == "major" for i in impacts)
+
+
+def test_added_required_option_is_major_click() -> None:
+    old = extract_cli(_click_v1())
+    new = extract_cli(_click_v2_required())
+    impacts = diff_cli(old, new)
+    assert any(i.severity == "major" for i in impacts)


### PR DESCRIPTION
## Summary
- add CLI analyzer to detect command/option changes across versions
- wire CLI analyzer into config and main decision flow
- test CLI analyzer behavior for argparse and click CLIs

## Testing
- `isort semverbump/analyzers/cli.py semverbump/analyzers/__init__.py semverbump/cli.py semverbump/config.py tests/test_cli_analyzer.py`
- `black semverbump/cli.py semverbump/analyzers/cli.py semverbump/analyzers/__init__.py semverbump/config.py tests/test_cli_analyzer.py`
- `ruff check semverbump/analyzers/cli.py semverbump/analyzers/__init__.py semverbump/cli.py semverbump/config.py tests/test_cli_analyzer.py --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee24d10c88322a4ea72469a0ea381