### PR TITLE
feat(migrations): analyze Alembic migrations for schema changes

### DIFF
--- a/semverbump/analyzers/__init__.py
+++ b/semverbump/analyzers/__init__.py
@@ -1,0 +1,1 @@
+"""Analyzer plugins for semverbump."""

--- a/semverbump/analyzers/migrations.py
+++ b/semverbump/analyzers/migrations.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import List, Optional
+
+from ..compare import Impact
+from ..config import Migrations
+from ..gitutils import changed_paths, read_file_at_ref
+
+
+class _UpgradeVisitor(ast.NodeVisitor):
+    """AST visitor that records schema-changing operations."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.impacts: List[Impact] = []
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: D401
+        """Record relevant Alembic operations."""
+
+        if isinstance(node.func, ast.Attribute) and isinstance(
+            node.func.value, ast.Name
+        ):
+            if node.func.value.id == "op":
+                attr = node.func.attr
+                if attr == "drop_column":
+                    self.impacts.append(Impact("major", self.path, "Dropped column"))
+                elif attr == "add_column":
+                    impact = _analyze_add_column(node, self.path)
+                    if impact:
+                        self.impacts.append(impact)
+                elif attr == "create_index":
+                    self.impacts.append(Impact("minor", self.path, "Added index"))
+        self.generic_visit(node)
+
+
+def _analyze_add_column(node: ast.Call, path: str) -> Optional[Impact]:
+    """Determine the impact of an ``op.add_column`` call."""
+
+    column = None
+    for arg in node.args:
+        if (
+            isinstance(arg, ast.Call)
+            and isinstance(arg.func, ast.Attribute)
+            and arg.func.attr == "Column"
+        ):
+            column = arg
+            break
+    if column is None:
+        return None
+
+    kwargs = {kw.arg: kw.value for kw in column.keywords if kw.arg}
+    nullable = True
+    if "nullable" in kwargs and isinstance(kwargs["nullable"], ast.Constant):
+        nullable = bool(kwargs["nullable"].value)
+    has_default = "default" in kwargs or "server_default" in kwargs
+    if not nullable and not has_default:
+        return Impact("major", path, "Added non-nullable column")
+    return Impact("minor", path, "Added column")
+
+
+def _analyze_content(path: str, content: str) -> List[Impact]:
+    """Parse migration source and collect impacts."""
+
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return []
+
+    impacts: List[Impact] = []
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "upgrade":
+            visitor = _UpgradeVisitor(path)
+            for stmt in node.body:
+                visitor.visit(stmt)
+            impacts.extend(visitor.impacts)
+    return impacts
+
+
+def analyze_migrations(
+    base: str, head: str, config: Migrations, cwd: str | Path | None = None
+) -> List[Impact]:
+    """Analyze Alembic migrations between two git references.
+
+    Args:
+        base: Base git reference to compare from.
+        head: Head git reference to compare to.
+        config: Migration analyzer settings.
+        cwd: Repository root.
+
+    Returns:
+        List of detected schema change impacts.
+    """
+
+    dirs = [str(Path(p)) for p in config.paths]
+    impacts: List[Impact] = []
+    for path in changed_paths(base, head, cwd=cwd):
+        if not path.endswith(".py"):
+            continue
+        if not any(path == d or path.startswith(f"{d}/") for d in dirs):
+            continue
+        content = read_file_at_ref(head, path, cwd=cwd)
+        if content is None:
+            continue
+        impacts.extend(_analyze_content(path, content))
+    return impacts

--- a/semverbump/config.py
+++ b/semverbump/config.py
@@ -10,6 +10,7 @@ _DEFAULTS = {
     "ignore": {"paths": ["tests/**", "examples/**", "scripts/**"]},
     "rules": {"return_type_change": "minor"},  # or "major"
     "analyzers": {},
+    "migrations": {"paths": ["migrations"]},
 }
 
 
@@ -50,6 +51,13 @@ class Analyzers:
 
 
 @dataclass
+class Migrations:
+    """Settings for the migrations analyzer."""
+
+    paths: List[str] = field(default_factory=lambda: ["migrations"])
+
+
+@dataclass
 class Config:
     """Top-level configuration for semverbump.
 
@@ -64,6 +72,7 @@ class Config:
     rules: Rules = field(default_factory=Rules)
     ignore: Ignore = field(default_factory=Ignore)
     analyzers: Analyzers = field(default_factory=Analyzers)
+    migrations: Migrations = field(default_factory=Migrations)
 
 
 def _merge_defaults(data: dict) -> dict:
@@ -93,4 +102,11 @@ def load_config(path: str | Path = "semverbump.toml") -> Config:
     ign = Ignore(**d["ignore"])
     enabled = {name for name, enabled in d["analyzers"].items() if enabled}
     analyzers = Analyzers(enabled=enabled)
-    return Config(project=proj, rules=rules, ignore=ign, analyzers=analyzers)
+    migrations = Migrations(**d.get("migrations", {}))
+    return Config(
+        project=proj,
+        rules=rules,
+        ignore=ign,
+        analyzers=analyzers,
+        migrations=migrations,
+    )

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,102 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from semverbump.analyzers.migrations import analyze_migrations
+from semverbump.config import Migrations
+
+
+def _run(cmd: list[str], cwd: Path) -> str:
+    res = subprocess.run(cmd, cwd=cwd, check=True, stdout=subprocess.PIPE, text=True)
+    return res.stdout.strip()
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    _run(["git", "init"], tmp_path)
+    _run(["git", "config", "user.email", "a@b.c"], tmp_path)
+    _run(["git", "config", "user.name", "tester"], tmp_path)
+    (tmp_path / "README.md").write_text("init")
+    _run(["git", "add", "README.md"], tmp_path)
+    _run(["git", "commit", "-m", "init"], tmp_path)
+    return tmp_path
+
+
+def _commit_migration(repo: Path, name: str, content: str) -> str:
+    mig_dir = repo / "migrations"
+    mig_dir.mkdir(exist_ok=True)
+    (mig_dir / name).write_text(content)
+    _run(["git", "add", str(mig_dir)], repo)
+    _run(["git", "commit", "-m", name], repo)
+    return _run(["git", "rev-parse", "HEAD"], repo)
+
+
+def _baseline(repo: Path) -> str:
+    return _run(["git", "rev-parse", "HEAD"], repo)
+
+
+def test_add_nullable_column_minor(repo: Path) -> None:
+    base = _baseline(repo)
+    head = _commit_migration(
+        repo,
+        "0001_add_col.py",
+        """
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.add_column('t', sa.Column('c', sa.Integer(), nullable=True))
+""",
+    )
+    impacts = analyze_migrations(base, head, Migrations(paths=["migrations"]), cwd=repo)
+    assert any(i.severity == "minor" for i in impacts)
+
+
+def test_drop_column_major(repo: Path) -> None:
+    base = _baseline(repo)
+    head = _commit_migration(
+        repo,
+        "0002_drop_col.py",
+        """
+from alembic import op
+
+def upgrade():
+    op.drop_column('t', 'c')
+""",
+    )
+    impacts = analyze_migrations(base, head, Migrations(paths=["migrations"]), cwd=repo)
+    assert any(i.severity == "major" for i in impacts)
+
+
+def test_add_non_nullable_no_default_major(repo: Path) -> None:
+    base = _baseline(repo)
+    head = _commit_migration(
+        repo,
+        "0003_add_nn.py",
+        """
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.add_column('t', sa.Column('d', sa.Integer(), nullable=False))
+""",
+    )
+    impacts = analyze_migrations(base, head, Migrations(paths=["migrations"]), cwd=repo)
+    assert any(i.severity == "major" for i in impacts)
+
+
+def test_create_index_minor(repo: Path) -> None:
+    base = _baseline(repo)
+    head = _commit_migration(
+        repo,
+        "0004_add_index.py",
+        """
+from alembic import op
+
+def upgrade():
+    op.create_index('ix_t_c', 't', ['c'])
+""",
+    )
+    impacts = analyze_migrations(base, head, Migrations(paths=["migrations"]), cwd=repo)
+    assert any(i.severity == "minor" for i in impacts)


### PR DESCRIPTION
## Summary
- add Alembic migrations analyzer to flag schema changes
- support configurable migration directories via semverbump.toml
- test migration scenarios for major and minor bumps

## Testing
- `isort semverbump/analyzers/migrations.py semverbump/config.py tests/test_migrations.py`
- `black semverbump/analyzers/migrations.py semverbump/config.py tests/test_migrations.py`
- `ruff check semverbump/analyzers/migrations.py semverbump/config.py tests/test_migrations.py`
- `ruff check semverbump/analyzers/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee2470c5883228de407a71c16efe4