### PR TITLE
feat(analyzer): add web route analyzer

### DIFF
--- a/semverbump/analyzers/__init__.py
+++ b/semverbump/analyzers/__init__.py
@@ -1,0 +1,21 @@
+"""Analyzer plugin registry."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+from ..compare import Impact
+from ..config import Config
+
+Analyzer = Callable[[str, str, Config], List[Impact]]
+
+REGISTRY: Dict[str, Analyzer] = {}
+
+
+def register(name: str, func: Analyzer) -> None:
+    """Register an analyzer function."""
+    REGISTRY[name] = func
+
+
+# Import built-in analyzers for registration side-effects
+from . import web_routes  # noqa: F401,E402

--- a/semverbump/analyzers/web_routes.py
+++ b/semverbump/analyzers/web_routes.py
@@ -1,0 +1,161 @@
+"""Web route analyzer for Flask and FastAPI apps."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple
+
+from ..compare import Impact
+from ..config import Config
+from ..gitutils import list_py_files_at_ref, read_file_at_ref
+from . import register
+
+HTTP_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"}
+
+
+@dataclass(frozen=True)
+class Route:
+    """Represent a single HTTP route."""
+
+    path: str
+    method: str
+    params: Dict[str, bool]  # True if required
+
+
+def _is_const_str(node: ast.AST) -> bool:
+    return isinstance(node, ast.Constant) and isinstance(node.value, str)
+
+
+def _extract_params(args: ast.arguments) -> Dict[str, bool]:
+    """Extract function parameters and whether they are required.
+
+    Args:
+        args: AST arguments object.
+
+    Returns:
+        Mapping of parameter name to required flag.
+    """
+
+    params: Dict[str, bool] = {}
+    pos = list(args.posonlyargs) + list(args.args)
+    defaults = [None] * (len(pos) - len(args.defaults)) + list(args.defaults)
+    for a, d in zip(pos, defaults):
+        if a.arg == "self":
+            continue
+        required = d is None
+        params[a.arg] = required
+    for a, d in zip(args.kwonlyargs, args.kw_defaults):
+        required = d is None
+        params[a.arg] = required
+    return params
+
+
+def extract_routes_from_source(code: str) -> Dict[Tuple[str, str], Route]:
+    """Extract routes from source code.
+
+    Args:
+        code: Module source code.
+
+    Returns:
+        Mapping of (path, method) to :class:`Route` objects.
+    """
+
+    tree = ast.parse(code)
+    routes: Dict[Tuple[str, str], Route] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        path = None
+        methods: Iterable[str] | None = None
+        for deco in node.decorator_list:
+            if isinstance(deco, ast.Call) and isinstance(deco.func, ast.Attribute):
+                name = deco.func.attr.lower()
+                if name == "route":  # Flask
+                    if deco.args and _is_const_str(deco.args[0]):
+                        path = deco.args[0].value  # type: ignore[assignment]
+                    for kw in deco.keywords:
+                        if kw.arg == "methods" and isinstance(
+                            kw.value, (ast.List, ast.Tuple)
+                        ):
+                            methods = [
+                                elt.value.upper()
+                                for elt in kw.value.elts
+                                if _is_const_str(elt)
+                            ]
+                    if methods is None:
+                        methods = ["GET"]
+                elif name.upper() in HTTP_METHODS:  # FastAPI style
+                    if deco.args and _is_const_str(deco.args[0]):
+                        path = deco.args[0].value  # type: ignore[assignment]
+                        methods = [name.upper()]
+        if path and methods:
+            params = _extract_params(node.args)
+            for m in methods:
+                routes[(path, m)] = Route(path, m, params)
+    return routes
+
+
+def _build_routes_at_ref(
+    ref: str, roots: Iterable[str]
+) -> Dict[Tuple[str, str], Route]:
+    """Collect routes for all modules under given roots at a git ref."""
+
+    out: Dict[Tuple[str, str], Route] = {}
+    for root in roots:
+        for path in list_py_files_at_ref(ref, [root]):
+            code = read_file_at_ref(ref, path)
+            if code is None:
+                continue
+            out.update(extract_routes_from_source(code))
+    return out
+
+
+def diff_routes(
+    old: Dict[Tuple[str, str], Route], new: Dict[Tuple[str, str], Route]
+) -> List[Impact]:
+    """Compute impacts between two route mappings."""
+
+    impacts: List[Impact] = []
+
+    for key in old.keys() - new.keys():
+        path, method = key
+        impacts.append(Impact("major", f"{method} {path}", "Removed route"))
+
+    for key in new.keys() - old.keys():
+        path, method = key
+        impacts.append(Impact("minor", f"{method} {path}", "Added route"))
+
+    for key in old.keys() & new.keys():
+        op = old[key].params
+        np = new[key].params
+        path, method = key
+        symbol = f"{method} {path}"
+        for p in op.keys() - np.keys():
+            if op[p]:
+                impacts.append(Impact("major", symbol, f"Removed required param '{p}'"))
+            else:
+                impacts.append(Impact("minor", symbol, f"Removed optional param '{p}'"))
+        for p in np.keys() - op.keys():
+            if np[p]:
+                impacts.append(Impact("major", symbol, f"Added required param '{p}'"))
+            else:
+                impacts.append(Impact("minor", symbol, f"Added optional param '{p}'"))
+        for p in op.keys() & np.keys():
+            if op[p] and not np[p]:
+                impacts.append(Impact("minor", symbol, f"Param '{p}' became optional"))
+            if not op[p] and np[p]:
+                impacts.append(Impact("major", symbol, f"Param '{p}' became required"))
+    return impacts
+
+
+def analyze(base: str, head: str, cfg: Config) -> List[Impact]:
+    """Analyzer entry point used by the plugin registry."""
+
+    old = _build_routes_at_ref(base, cfg.project.public_roots)
+    new = _build_routes_at_ref(head, cfg.project.public_roots)
+    return diff_routes(old, new)
+
+
+register("web_routes", analyze)

--- a/semverbump/cli.py
+++ b/semverbump/cli.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
-import argparse, json, sys
-from pathlib import Path
-from typing import Dict, List
-from .config import load_config
+
+import argparse
+import json
+import sys
+from typing import List
+
+from .analyzers import REGISTRY as ANALYZERS
+from .compare import Impact, decide_bump, diff_public_api
+from .config import Config, load_config
 from .gitutils import list_py_files_at_ref, read_file_at_ref
-from .public_api import extract_public_api_from_source, module_name_from_path, PublicAPI
-from .compare import diff_public_api, decide_bump
+from .public_api import PublicAPI, extract_public_api_from_source, module_name_from_path
 from .versioning import apply_bump
+
 
 def _build_api_at_ref(ref: str, roots: list[str]) -> PublicAPI:
     api: PublicAPI = {}
@@ -20,25 +25,42 @@ def _build_api_at_ref(ref: str, roots: list[str]) -> PublicAPI:
             api.update(extract_public_api_from_source(modname, code))
     return api
 
+
 def _format_impacts_text(impacts) -> str:
     lines = []
     for i in impacts:
         lines.append(f"- [{i.severity.upper()}] {i.symbol}: {i.reason}")
     return "\n".join(lines) if lines else "(no API-impacting changes detected)"
 
+
+def _run_analyzers(base: str, head: str, cfg: Config) -> List[Impact]:
+    """Run enabled analyzer plugins."""
+
+    impacts: List[Impact] = []
+    for name in cfg.analyzers.enabled:
+        func = ANALYZERS.get(name)
+        if func:
+            impacts.extend(func(base, head, cfg))
+    return impacts
+
+
 def decide_cmd(args) -> int:
     cfg = load_config(args.config)
     old_api = _build_api_at_ref(args.base, cfg.project.public_roots)
     new_api = _build_api_at_ref(args.head, cfg.project.public_roots)
 
-    impacts = diff_public_api(old_api, new_api, return_type_change=cfg.rules.return_type_change)
+    impacts = diff_public_api(
+        old_api, new_api, return_type_change=cfg.rules.return_type_change
+    )
+    impacts.extend(_run_analyzers(args.base, args.head, cfg))
     level = decide_bump(impacts)
 
     if args.format == "json":
-        print(json.dumps({
-            "level": level,
-            "impacts": [i.__dict__ for i in impacts]
-        }, indent=2))
+        print(
+            json.dumps(
+                {"level": level, "impacts": [i.__dict__ for i in impacts]}, indent=2
+            )
+        )
     elif args.format == "md":
         print(f"**semverbump** suggests: `{level}`\n")
         print(_format_impacts_text(impacts))
@@ -47,6 +69,7 @@ def decide_cmd(args) -> int:
         print(_format_impacts_text(impacts))
     return 0
 
+
 def bump_cmd(args) -> int:
     # If level not provided, compute from base/head
     level = args.level
@@ -54,45 +77,67 @@ def bump_cmd(args) -> int:
         cfg = load_config(args.config)
         old_api = _build_api_at_ref(args.base, cfg.project.public_roots)
         new_api = _build_api_at_ref(args.head, cfg.project.public_roots)
-        impacts = diff_public_api(old_api, new_api, return_type_change=cfg.rules.return_type_change)
+        impacts = diff_public_api(
+            old_api, new_api, return_type_change=cfg.rules.return_type_change
+        )
+        impacts.extend(_run_analyzers(args.base, args.head, cfg))
         level = decide_bump(impacts)
 
     vc = apply_bump(level, pyproject_path=args.pyproject)
     print(f"Bumped version: {vc.old} -> {vc.new} ({vc.level})")
     if args.commit or args.tag:
         import subprocess
+
         # Commit
         if args.commit:
             subprocess.run(["git", "add", args.pyproject], check=True)
-            subprocess.run(["git", "commit", "-m", f"chore(release): {vc.new}"], check=True)
+            subprocess.run(
+                ["git", "commit", "-m", f"chore(release): {vc.new}"], check=True
+            )
         # Tag
         if args.tag:
             subprocess.run(["git", "tag", f"v{vc.new}"], check=True)
     return 0
 
+
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="semverbump", description="Suggest and apply semantic version bumps.")
-    parser.add_argument("--config", default="semverbump.toml", help="Path to config (default: semverbump.toml)")
+    parser = argparse.ArgumentParser(
+        prog="semverbump", description="Suggest and apply semantic version bumps."
+    )
+    parser.add_argument(
+        "--config",
+        default="semverbump.toml",
+        help="Path to config (default: semverbump.toml)",
+    )
 
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     p_decide = sub.add_parser("decide", help="Suggest bump between two refs")
-    p_decide.add_argument("--base", required=True, help="Base ref (e.g., origin/master)")
+    p_decide.add_argument(
+        "--base", required=True, help="Base ref (e.g., origin/master)"
+    )
     p_decide.add_argument("--head", default="HEAD", help="Head ref (default: HEAD)")
     p_decide.add_argument("--format", choices=["text", "md", "json"], default="text")
     p_decide.set_defaults(func=decide_cmd)
 
     p_bump = sub.add_parser("bump", help="Apply a bump to pyproject.toml")
-    p_bump.add_argument("--level", choices=["major", "minor", "patch"], help="Bump level; if omitted, auto-decide from refs")
+    p_bump.add_argument(
+        "--level",
+        choices=["major", "minor", "patch"],
+        help="Bump level; if omitted, auto-decide from refs",
+    )
     p_bump.add_argument("--base", help="Base ref (for auto decide)")
     p_bump.add_argument("--head", default="HEAD", help="Head ref (for auto decide)")
     p_bump.add_argument("--pyproject", default="pyproject.toml")
-    p_bump.add_argument("--commit", action="store_true", help="git commit the version change")
+    p_bump.add_argument(
+        "--commit", action="store_true", help="git commit the version change"
+    )
     p_bump.add_argument("--tag", action="store_true", help="git tag the new version")
     p_bump.set_defaults(func=bump_cmd)
 
     args = parser.parse_args(argv)
     return args.func(args)
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -1,0 +1,71 @@
+from semverbump.analyzers.web_routes import diff_routes, extract_routes_from_source
+
+
+def _build(src: str):
+    return extract_routes_from_source(src)
+
+
+def test_removed_route_is_major():
+    old = _build(
+        """
+from flask import Flask
+app = Flask(__name__)
+
+@app.route('/a')
+def a():
+    return 'ok'
+"""
+    )
+    new = {}
+    impacts = diff_routes(old, new)
+    assert any(i.severity == "major" for i in impacts)
+
+
+def test_param_optional_to_required_is_major():
+    old = _build(
+        """
+from fastapi import FastAPI
+app = FastAPI()
+
+@app.get('/a')
+def a(q: int | None = None):
+    return q
+"""
+    )
+    new = _build(
+        """
+from fastapi import FastAPI
+app = FastAPI()
+
+@app.get('/a')
+def a(q: int):
+    return q
+"""
+    )
+    impacts = diff_routes(old, new)
+    assert any(i.severity == "major" for i in impacts)
+
+
+def test_added_query_param_is_minor():
+    old = _build(
+        """
+from fastapi import FastAPI
+app = FastAPI()
+
+@app.get('/a')
+def a():
+    return 1
+"""
+    )
+    new = _build(
+        """
+from fastapi import FastAPI
+app = FastAPI()
+
+@app.get('/a')
+def a(limit: int | None = None):
+    return 1
+"""
+    )
+    impacts = diff_routes(old, new)
+    assert any(i.severity == "minor" for i in impacts)


### PR DESCRIPTION
## Summary
- add analyzer to diff Flask/FastAPI routes
- register analyzers and run them from the CLI
- test route diffs for removed and optional parameters

## Testing
- `ruff check semverbump/analyzers/web_routes.py semverbump/analyzers/__init__.py semverbump/cli.py tests/test_web_routes.py`
- `isort semverbump/analyzers/web_routes.py semverbump/analyzers/__init__.py semverbump/cli.py tests/test_web_routes.py`
- `black semverbump/analyzers/web_routes.py semverbump/analyzers/__init__.py semverbump/cli.py tests/test_web_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee242deb88322bf77a8ec3b392528