### PR TITLE
feat(analyzers): add plugin registry with ignore support

### DIFF
--- a/semverbump/analyzers/__init__.py
+++ b/semverbump/analyzers/__init__.py
@@ -2,19 +2,55 @@
 
 from __future__ import annotations
 
-from typing import Callable, Dict, List
+from typing import Dict, List, Protocol, Type
 
 from ..compare import Impact
 from ..config import Config
 
-Analyzer = Callable[[str, str, Config], List[Impact]]
 
-REGISTRY: Dict[str, Analyzer] = {}
+class Analyzer(Protocol):
+    """Protocol for analyzer plugins.
+
+    An analyzer collects state for a given git reference and compares two
+    states to produce :class:`Impact` entries.
+    """
+
+    def __init__(self, cfg: Config) -> None:
+        """Initialize the analyzer with configuration."""
+
+    def collect(self, ref: str) -> object:
+        """Collect analyzer-specific state at ``ref``."""
+
+    def compare(self, old: object, new: object) -> List[Impact]:
+        """Compare two states and return impacts."""
 
 
-def register(name: str, func: Analyzer) -> None:
-    """Register an analyzer function."""
-    REGISTRY[name] = func
+REGISTRY: Dict[str, Type[Analyzer]] = {}
+
+
+def register(name: str):
+    """Decorator registering an analyzer implementation."""
+
+    def _wrap(cls: Type[Analyzer]) -> Type[Analyzer]:
+        REGISTRY[name] = cls
+        return cls
+
+    return _wrap
+
+
+def load_enabled(cfg: Config) -> List[Analyzer]:
+    """Instantiate analyzers enabled via configuration."""
+    out: List[Analyzer] = []
+    for name in cfg.analyzers.enabled:
+        cls = REGISTRY.get(name)
+        if cls:
+            out.append(cls(cfg))
+    return out
+
+
+def available() -> List[str]:
+    """Return names of all registered analyzers."""
+    return sorted(REGISTRY.keys())
 
 
 # Import built-in analyzers for registration side-effects

--- a/semverbump/gitutils.py
+++ b/semverbump/gitutils.py
@@ -1,30 +1,64 @@
 from __future__ import annotations
+
 import subprocess
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Iterable, List, Optional, Set
 
+
 def _run(cmd: List[str], cwd: str | None = None) -> str:
-    res = subprocess.run(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+    res = subprocess.run(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
     if res.returncode != 0:
         raise RuntimeError(f"Command failed: {' '.join(cmd)}\n{res.stderr}")
     return res.stdout
+
 
 def changed_paths(base: str, head: str, cwd: str | None = None) -> Set[str]:
     out = _run(["git", "diff", "--name-only", f"{base}..{head}"], cwd)
     return {line.strip() for line in out.splitlines() if line.strip()}
 
-def list_py_files_at_ref(ref: str, roots: Iterable[str], cwd: str | None = None) -> Set[str]:
-    # List tracked files, then filter by root and .py extension.
+
+def list_py_files_at_ref(
+    ref: str,
+    roots: Iterable[str],
+    ignore_globs: Iterable[str] | None = None,
+    cwd: str | None = None,
+) -> Set[str]:
+    """List Python files under given roots at a git ref.
+
+    Args:
+        ref: Git reference to inspect.
+        roots: Root directories to include.
+        ignore_globs: Optional glob patterns to exclude.
+        cwd: Repository path.
+
+    Returns:
+        Set of matching Python file paths.
+    """
+
     out = _run(["git", "ls-tree", "-r", "--name-only", ref], cwd)
-    paths = []
+    paths: List[str] = []
     roots_norm = [str(Path(r)) for r in roots]
     for line in out.splitlines():
         if not line.endswith(".py"):
             continue
         p = Path(line)
-        if any(str(p).startswith(r.rstrip("/") + "/") or str(p) == r for r in roots_norm):
-            paths.append(str(p))
+        if any(
+            str(p).startswith(r.rstrip("/") + "/") or str(p) == r for r in roots_norm
+        ):
+            s = str(p)
+            if ignore_globs and any(fnmatch(s, pat) for pat in ignore_globs):
+                continue
+            paths.append(s)
     return set(paths)
+
 
 def read_file_at_ref(ref: str, path: str, cwd: str | None = None) -> Optional[str]:
     try:

--- a/tests/test_cli_analyzer.py
+++ b/tests/test_cli_analyzer.py
@@ -1,4 +1,10 @@
-from semverbump.analyzers.cli import diff_cli, extract_cli_from_source
+import os
+import subprocess
+from pathlib import Path
+
+from semverbump.analyzers import load_enabled
+from semverbump.analyzers.cli import CLIAnalyzer, diff_cli, extract_cli_from_source
+from semverbump.config import Config, Ignore, Project
 
 
 def _build(src: str):
@@ -72,3 +78,61 @@ def cli(name):
     )
     impacts = diff_cli(old, new)
     assert any(i.severity == "major" for i in impacts)
+
+
+def _run(cmd: list[str], cwd: Path) -> str:
+    res = subprocess.run(cmd, cwd=cwd, check=True, stdout=subprocess.PIPE, text=True)
+    return res.stdout.strip()
+
+
+def test_cli_analyzer_respects_ignore(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init"], repo)
+    _run(["git", "config", "user.email", "a@b.c"], repo)
+    _run(["git", "config", "user.name", "tester"], repo)
+    (repo / "main.py").write_text(
+        """
+import click
+
+@click.command()
+def a():
+    pass
+"""
+    )
+    _run(["git", "add", "main.py"], repo)
+    _run(["git", "commit", "-m", "base"], repo)
+    base = _run(["git", "rev-parse", "HEAD"], repo)
+
+    (repo / "tests").mkdir()
+    (repo / "tests" / "cli.py").write_text(
+        """
+import click
+
+@click.command()
+def b():
+    pass
+"""
+    )
+    _run(["git", "add", "tests"], repo)
+    _run(["git", "commit", "-m", "add ignored"], repo)
+    head = _run(["git", "rev-parse", "HEAD"], repo)
+
+    cfg = Config(project=Project(public_roots=["."]), ignore=Ignore(paths=["tests/**"]))
+    analyzer = CLIAnalyzer(cfg)
+    old_cwd = os.getcwd()
+    os.chdir(repo)
+    try:
+        old = analyzer.collect(base)
+        new = analyzer.collect(head)
+    finally:
+        os.chdir(old_cwd)
+    impacts = analyzer.compare(old, new)
+    assert impacts == []
+
+
+def test_load_enabled_instantiates_plugins() -> None:
+    cfg = Config()
+    cfg.analyzers.enabled.add("cli")
+    analyzers = load_enabled(cfg)
+    assert any(isinstance(a, CLIAnalyzer) for a in analyzers)


### PR DESCRIPTION
## Summary
- implement Analyzer protocol with registry and configuration-driven loading
- respect configured ignore paths in analyzers and git file listing
- surface available analyzers in CLI help and aggregate their impacts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee621a8988322a497ae4dd2adfd61