### PR TITLE
fix(cli): mark nargs '+' arguments as required

### DIFF
--- a/semverbump/analyzers/cli.py
+++ b/semverbump/analyzers/cli.py
@@ -125,6 +125,8 @@ def _extract_argparse(tree: ast.AST) -> Dict[str, Command]:
                     if kw.arg == "nargs" and isinstance(kw.value, ast.Constant):
                         if kw.value.value in ("?", "*"):
                             required = False
+                        if kw.value.value == "+":
+                            required = True
                 if name:
                     cmd.options[name] = required
     return commands

--- a/tests/test_cli_analyzer.py
+++ b/tests/test_cli_analyzer.py
@@ -80,6 +80,29 @@ def cli(name):
     assert any(i.severity == "major" for i in impacts)
 
 
+def test_argparse_nargs_plus_major():
+    old = _build(
+        """
+import argparse
+parser = argparse.ArgumentParser()
+sub = parser.add_subparsers()
+p_run = sub.add_parser('run')
+p_run.add_argument('--files')
+"""
+    )
+    new = _build(
+        """
+import argparse
+parser = argparse.ArgumentParser()
+sub = parser.add_subparsers()
+p_run = sub.add_parser('run')
+p_run.add_argument('--files', nargs='+')
+"""
+    )
+    impacts = diff_cli(old, new)
+    assert any(i.severity == "major" for i in impacts)
+
+
 def _run(cmd: list[str], cwd: Path) -> str:
     res = subprocess.run(cmd, cwd=cwd, check=True, stdout=subprocess.PIPE, text=True)
     return res.stdout.strip()


### PR DESCRIPTION
## Summary
- treat argparse arguments with `nargs='+'` as required
- test CLI analyzer for `nargs='+'` handling

## Testing
- `ruff check semverbump/analyzers/cli.py tests/test_cli_analyzer.py`
- `isort semverbump/analyzers/cli.py tests/test_cli_analyzer.py`
- `black semverbump/analyzers/cli.py tests/test_cli_analyzer.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689eedd246208322880d94ec48dd8836