### PR TITLE
refactor(gitutils): use set for path collection

### DIFF
--- a/semverbump/gitutils.py
+++ b/semverbump/gitutils.py
@@ -68,7 +68,7 @@ def list_py_files_at_ref(
     """
 
     out = _run(["git", "ls-tree", "-r", "--name-only", ref], cwd)
-    paths: List[str] = []
+    paths: Set[str] = set()
     roots_norm = [str(Path(r)) for r in roots]
     for line in out.splitlines():
         if not line.endswith(".py"):
@@ -80,8 +80,8 @@ def list_py_files_at_ref(
             s = str(p)
             if ignore_globs and any(fnmatch(s, pat) for pat in ignore_globs):
                 continue
-            paths.append(s)
-    return set(paths)
+            paths.add(s)
+    return paths
 
 
 def read_file_at_ref(ref: str, path: str, cwd: str | None = None) -> Optional[str]:

--- a/tests/test_gitutils.py
+++ b/tests/test_gitutils.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Iterable, List, Set
+
+from semverbump import gitutils
+
+
+def _legacy_list_py_files_at_ref(
+    ref: str,
+    roots: Iterable[str],
+    ignore_globs: Iterable[str] | None = None,
+    cwd: str | None = None,
+) -> Set[str]:
+    """Legacy helper to mirror previous list-based implementation."""
+    out = gitutils._run(["git", "ls-tree", "-r", "--name-only", ref], cwd)
+    paths: List[str] = []
+    roots_norm = [str(Path(r)) for r in roots]
+    for line in out.splitlines():
+        if not line.endswith(".py"):
+            continue
+        p = Path(line)
+        if any(
+            str(p).startswith(r.rstrip("/") + "/") or str(p) == r for r in roots_norm
+        ):
+            s = str(p)
+            if ignore_globs and any(fnmatch(s, pat) for pat in ignore_globs):
+                continue
+            paths.append(s)
+    return set(paths)
+
+
+def test_list_py_files_at_ref_matches_legacy(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pkg").mkdir()
+    (repo / "pkg" / "__init__.py").write_text("\n")
+    (repo / "pkg" / "ignored.py").write_text("\n")
+    (repo / "root.py").write_text("\n")
+    gitutils._run(["git", "init"], str(repo))
+    gitutils._run(["git", "config", "user.email", "test@example.com"], str(repo))
+    gitutils._run(["git", "config", "user.name", "Test"], str(repo))
+    gitutils._run(["git", "add", "."], str(repo))
+    gitutils._run(["git", "commit", "-m", "init"], str(repo))
+
+    ignore = ["pkg/ignored.py"]
+    expected = _legacy_list_py_files_at_ref("HEAD", ["."], ignore, str(repo))
+    result = gitutils.list_py_files_at_ref("HEAD", ["."], ignore, str(repo))
+
+    assert result == expected


### PR DESCRIPTION
## Summary
- replace list with set in list_py_files_at_ref
- add regression test ensuring set-based logic matches legacy behavior

## Testing
- `isort semverbump/gitutils.py tests/test_gitutils.py`
- `black semverbump/gitutils.py tests/test_gitutils.py`
- `ruff check --fix semverbump/gitutils.py tests/test_gitutils.py`
- `pytest`

Labels: refactor

------
https://chatgpt.com/codex/tasks/task_e_689eedcf8fdc832283ccd21133417f32