### PR TITLE
feat(package): expose CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [project.scripts]
-semverbump = "semverbump.cli:main"
+semverbump = "semverbump:main"
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/semverbump/__init__.py
+++ b/semverbump/__init__.py
@@ -1,3 +1,13 @@
-__all__ = ["__version__"]
-__version__ = "0.1.0"
+"""Top-level package for :mod:`semverbump`.
 
+Exposes the ``main`` entry point used by the command-line interface. The
+package is intended primarily for CLI usage rather than direct imports.
+"""
+
+from __future__ import annotations
+
+from .cli import main
+
+__all__ = ["__version__", "main"]
+
+__version__ = "0.1.0"

--- a/semverbump/analyzers/__init__.py
+++ b/semverbump/analyzers/__init__.py
@@ -55,3 +55,10 @@ def available() -> List[str]:
 
 # Import built-in analyzers for registration side-effects
 from . import cli, web_routes  # noqa: F401,E402
+
+__all__ = [
+    "Analyzer",
+    "register",
+    "load_enabled",
+    "available",
+]


### PR DESCRIPTION
## Summary
- expose `main` in package init for easier CLI access
- export analyzer registry helpers via `__all__`
- point console script to package `main`

## Testing
- `isort semverbump/__init__.py semverbump/analyzers/__init__.py`
- `black semverbump/__init__.py semverbump/analyzers/__init__.py`
- `ruff check --fix semverbump/__init__.py semverbump/analyzers/__init__.py pyproject.toml`
- `PYTHONDONTWRITEBYTECODE=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_689efd99c1448322b058efc33e68d352