### PR TITLE
chore(ci): add test workflow and optional dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+      - name: Run tests
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,16 @@ dependencies = [
 [project.scripts]
 semverbump = "semverbump.cli:main"
 
+[project.optional-dependencies]
+test = [
+  "pytest",
+  "flask",
+  "fastapi",
+  "alembic",
+  "sqlalchemy",
+  "click",
+]
+
 [tool.pytest.ini_options]
 addopts = "-q"
 


### PR DESCRIPTION
## Summary
- add CI workflow to install test extras and run pytest
- declare test-only optional dependencies in pyproject

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat 3 files)*
- `isort --check-only .` *(fails: imports not sorted in existing files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689efd73077c83228cbc3ff048bab324