### PR TITLE
fix(config): add tomli fallback for Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,14 @@ name = "semverbump"
 version = "0.1.0"
 description = "Static public-API diff + heuristics to suggest semantic version bumps."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 authors = [{ name = "Lewis Morris", email = "lewis@arched.dev"}]
-dependencies = [
-  "libcst>=1.4.0",
-  "tomlkit>=0.13.2",
-  "packaging>=24.0"
-]
+  dependencies = [
+    "libcst>=1.4.0",
+    "tomlkit>=0.13.2",
+    "packaging>=24.0",
+    "tomli>=1.0.0; python_version < '3.11'"
+  ]
 
 [project.scripts]
 semverbump = "semverbump.cli:main"

--- a/semverbump/config.py
+++ b/semverbump/config.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-import tomllib
+try:  # pragma: no cover - exercised in Python <3.11 tests
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Set

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,8 @@
+import builtins
+import importlib
+
+import tomli
+
 from semverbump.config import load_config
 
 
@@ -11,3 +16,22 @@ def test_load_config_parses_analyzers(tmp_path):
 def test_load_config_defaults_analyzers(tmp_path):
     cfg = load_config(tmp_path / "missing.toml")
     assert cfg.analyzers.enabled == set()
+
+
+def test_tomli_fallback(monkeypatch, tmp_path):
+    """Ensure ``tomli`` is used when ``tomllib`` is unavailable."""
+    import semverbump.config as config
+
+    original_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "tomllib":  # Simulate missing stdlib module
+            raise ModuleNotFoundError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    importlib.reload(config)
+
+    assert config.tomllib is tomli
+    cfg = config.load_config(tmp_path / "missing.toml")
+    assert cfg.project.index_file == "pyproject.toml"


### PR DESCRIPTION
## Summary
- support Python 3.10 by falling back to `tomli` when `tomllib` is unavailable
- declare `tomli` as a dependency for Python < 3.11
- test configuration loading including fallback to `tomli`

## Testing
- `python -m isort semverbump/config.py tests/test_config.py`
- `python -m black semverbump/config.py tests/test_config.py`
- `python -m ruff check semverbump/config.py tests/test_config.py`
- `~/.pyenv/versions/3.11.12/bin/python -m pytest tests/test_config.py`
- `~/.pyenv/versions/3.10.17/bin/python -m pytest tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_689efd691ef483229c384c956be3a0b7