### PR TITLE
refactor(core): streamline analyzers and add module docs

### DIFF
--- a/semverbump/analyzers/cli.py
+++ b/semverbump/analyzers/cli.py
@@ -179,12 +179,11 @@ def _build_cli_at_ref(
     """Collect commands for all modules at a git ref."""
 
     out: Dict[str, Command] = {}
-    for root in roots:
-        for path in list_py_files_at_ref(ref, [root], ignore_globs=ignores):
-            code = read_file_at_ref(ref, path)
-            if code is None:
-                continue
-            out.update(extract_cli_from_source(code))
+    for path in list_py_files_at_ref(ref, roots, ignore_globs=ignores):
+        code = read_file_at_ref(ref, path)
+        if code is None:
+            continue
+        out.update(extract_cli_from_source(code))
     return out
 
 

--- a/semverbump/analyzers/migrations.py
+++ b/semverbump/analyzers/migrations.py
@@ -1,3 +1,10 @@
+"""Analyzer for Alembic database migrations.
+
+The utilities here parse migration scripts and flag schema changes such as
+added or removed columns. The analyzer reports these findings as public API
+impacts so they can influence semantic version recommendations.
+"""
+
 from __future__ import annotations
 
 import ast

--- a/semverbump/cli.py
+++ b/semverbump/cli.py
@@ -1,4 +1,8 @@
-"""Command-line interface for semverbump."""
+"""Command-line interface for the :mod:`semverbump` project.
+
+This module exposes subcommands for suggesting and applying semantic version
+bumps based on public API differences and additional analyzers.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- document CLI and analyzer modules with Google-style docstrings
- streamline analyzer file scanning for efficiency
- simplify parameter extraction logic in web route analyzer

## Testing
- `isort --profile=black semverbump/cli.py semverbump/analyzers/cli.py semverbump/analyzers/migrations.py semverbump/analyzers/web_routes.py`
- `black semverbump/cli.py semverbump/analyzers/cli.py semverbump/analyzers/migrations.py semverbump/analyzers/web_routes.py`
- `ruff check --fix semverbump/cli.py semverbump/analyzers/cli.py semverbump/analyzers/migrations.py semverbump/analyzers/web_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0749c6ac8322a9f5cca4dd53fe05