### PR TITLE
feat(tomli): add lightweight parser

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,6 @@ import builtins
 import importlib
 
 import tomli
-
 from semverbump.config import load_config
 
 
@@ -19,7 +18,7 @@ def test_load_config_defaults_analyzers(tmp_path):
 
 
 def test_tomli_fallback(monkeypatch, tmp_path):
-    """Ensure ``tomli`` is used when ``tomllib`` is unavailable."""
+    """Ensure ``tomli`` is used when ``tomllib`` is unavailable and parses TOML."""
     import semverbump.config as config
 
     original_import = builtins.__import__
@@ -32,6 +31,9 @@ def test_tomli_fallback(monkeypatch, tmp_path):
     monkeypatch.setattr(builtins, "__import__", fake_import)
     importlib.reload(config)
 
+    cfg_file = tmp_path / "semverbump.toml"
+    cfg_file.write_text('[project]\nindex_file = "custom.toml"\n')
+    cfg = config.load_config(cfg_file)
+
     assert config.tomllib is tomli
-    cfg = config.load_config(tmp_path / "missing.toml")
-    assert cfg.project.index_file == "pyproject.toml"
+    assert cfg.project.index_file == "custom.toml"

--- a/tomli/__init__.py
+++ b/tomli/__init__.py
@@ -1,14 +1,65 @@
-"""A tiny subset of the :mod:`tomli` API for tests.
+"""Minimal TOML parser for tests.
 
-The real project provides a TOML parser for Python versions lacking
-``tomllib``. For the purposes of the test suite we only need ``loads`` which
-can be satisfied by the standard library module.
+This module provides a tiny subset of the :mod:`tomli` interface used in the
+project's test suite. It supports only what the tests require: basic tables and
+string or boolean values. The implementation is intentionally simple and does
+not aim to be a full TOML parser.
 """
 
 from __future__ import annotations
 
-import tomllib as _tomllib
+from typing import Any, Dict
 
-loads = _tomllib.loads
+
+def loads(src: str) -> Dict[str, Any]:
+    """Parse a small subset of TOML into a dictionary.
+
+    The parser understands table headers (e.g. ``[section]``) and key-value
+    assignments where values are strings or booleans. It ignores blank lines and
+    comments beginning with ``#``.
+
+    Args:
+        src: TOML document as a string.
+
+    Returns:
+        Parsed representation as a nested dictionary.
+    """
+
+    result: Dict[str, Any] = {}
+    current: Dict[str, Any] = result
+
+    for raw_line in src.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].strip()
+            current = result.setdefault(section, {})
+            continue
+        if "=" in line:
+            key, value = map(str.strip, line.split("=", 1))
+            current[key] = _parse_value(value)
+    return result
+
+
+def _parse_value(value: str) -> Any:
+    """Parse a primitive TOML value.
+
+    Args:
+        value: Raw value string from the TOML document.
+
+    Returns:
+        The parsed Python object.
+
+    Raises:
+        ValueError: If the value uses an unsupported type.
+    """
+
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    if value in {"true", "false"}:
+        return value == "true"
+    raise ValueError(f"Unsupported value: {value!r}")
+
 
 __all__ = ["loads"]


### PR DESCRIPTION
## Summary
- replace tomli with lightweight parser for tests
- ensure config.load_config works without stdlib tomllib

## Testing
- `python -m isort tomli/__init__.py tests/test_config.py`
- `python -m black tomli/__init__.py tests/test_config.py`
- `ruff check tomli/__init__.py tests/test_config.py`
- `pytest`

## Labels
- feat

------
https://chatgpt.com/codex/tasks/task_e_689f11733400832288db1c336a14570d