### PR TITLE
feat(cli): add auto command for versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ pip install semverbump
    Omitting ``--level`` triggers an automatic decision using ``--base`` and
    ``--head`` in the same manner as the ``decide`` command.
 
+4. **Run everything in one step** and let semverbump infer the base reference:
+
+   ```console
+   $ semverbump auto --commit --tag
+   **semverbump** suggests: `minor`
+
+   - [MINOR] cli.new_command: added CLI entry 'greet'
+   Bumped version: 1.2.3 -> 1.3.0 (minor)
+   ```
+
+   When ``--base`` is omitted, the command uses the current branch's upstream
+   as the comparison reference.
+
 ## Configuration
 
 Only analysers explicitly set to ``true`` run. See ``docs/configuration.rst`` for

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -19,4 +19,4 @@ Apply a bump and commit/tag automatically:
 
 .. code-block:: console
 
-   semverbump bump --base v1.0.0 --head HEAD --commit --tag
+   semverbump auto --base v1.0.0 --head HEAD --commit --tag

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -35,6 +35,17 @@ the change.
 If ``--level`` is omitted, provide ``--base`` and ``--head`` and the command
 will automatically decide in the same fashion as ``decide``.
 
+Automatic bump
+--------------
+
+To decide and apply the bump in a single step, use the ``auto`` command. When
+``--base`` is omitted, the current branch's upstream is used as the comparison
+reference.
+
+.. code-block:: console
+
+   semverbump auto --commit --tag
+
 Full workflow
 -------------
 
@@ -45,8 +56,7 @@ A typical release sequence might look like this:
    git checkout -b feature/amazing-change
    # edit code
    git commit -am "feat: add amazing change"
-   semverbump decide --base origin/main --head HEAD --format md
-   semverbump bump --level minor --commit --tag
+   semverbump auto --commit --tag
    git push --follow-tags origin HEAD
 
 Both commands read configuration from ``semverbump.toml`` by default. Use

--- a/tests/test_cli_auto.py
+++ b/tests/test_cli_auto.py
@@ -1,0 +1,67 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from semverbump.versioning import read_project_version
+
+
+def _run(cmd: list[str], cwd: Path) -> str:
+    res = subprocess.run(cmd, cwd=cwd, check=True, stdout=subprocess.PIPE, text=True)
+    return res.stdout.strip()
+
+
+def test_auto_command_bumps_version(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init"], repo)
+    _run(["git", "config", "user.email", "a@b.c"], repo)
+    _run(["git", "config", "user.name", "tester"], repo)
+
+    (repo / "pyproject.toml").write_text(
+        """
+[project]
+name = "demo"
+version = "0.1.0"
+""",
+        encoding="utf-8",
+    )
+
+    pkg = repo / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(
+        "def foo() -> int:\n    return 1\n", encoding="utf-8"
+    )
+    (repo / "semverbump.toml").write_text(
+        "[project]\npublic_roots=['pkg']\n", encoding="utf-8"
+    )
+    _run(["git", "add", "."], repo)
+    _run(["git", "commit", "-m", "base"], repo)
+    base = _run(["git", "rev-parse", "HEAD"], repo)
+
+    (pkg / "extra.py").write_text("def bar() -> int:\n    return 2\n", encoding="utf-8")
+    _run(["git", "add", "pkg/extra.py"], repo)
+    _run(["git", "commit", "-m", "feat: add bar"], repo)
+
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "semverbump.cli",
+            "auto",
+            "--base",
+            base,
+            "--head",
+            "HEAD",
+            "--pyproject",
+            "pyproject.toml",
+        ],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])},
+    )
+
+    assert "Bumped version: 0.1.0 -> 0.2.0 (minor)" in res.stdout
+    assert read_project_version(repo / "pyproject.toml") == "0.2.0"


### PR DESCRIPTION
## Summary
- add `auto` command to combine decide and bump steps
- infer upstream git reference when base not provided
- document `auto` workflow and add test coverage

## Testing
- `isort tests/test_cli_auto.py semverbump/cli.py docs/usage.rst docs/advanced.rst README.md`
- `black tests/test_cli_auto.py semverbump/cli.py`
- `ruff check tests/test_cli_auto.py semverbump/cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f156fe2f483228d3a9bb93972316c