### PR TITLE
feat(cli): add dry-run mode for version bumps

### DIFF
--- a/semverbump/cli.py
+++ b/semverbump/cli.py
@@ -183,9 +183,10 @@ def bump_command(args: argparse.Namespace) -> int:
         impacts.extend(_run_analyzers(base, head, cfg))
         level = decide_bump(impacts)
 
-    vc = apply_bump(level, pyproject_path=args.pyproject)
+    vc = apply_bump(level, pyproject_path=args.pyproject, dry_run=args.dry_run)
     print(f"Bumped version: {vc.old} -> {vc.new} ({vc.level})")
-    _commit_tag(args.pyproject, vc.new, args.commit, args.tag)
+    if not args.dry_run:
+        _commit_tag(args.pyproject, vc.new, args.commit, args.tag)
     return 0
 
 
@@ -209,7 +210,7 @@ def auto_command(args: argparse.Namespace) -> int:
     )
     impacts.extend(_run_analyzers(base, head, cfg))
     level = decide_bump(impacts)
-    vc = apply_bump(level, pyproject_path=args.pyproject)
+    vc = apply_bump(level, pyproject_path=args.pyproject, dry_run=args.dry_run)
 
     if args.format == "json":
         print(
@@ -233,7 +234,8 @@ def auto_command(args: argparse.Namespace) -> int:
         print(_format_impacts_text(impacts))
         print(f"Bumped version: {vc.old} -> {vc.new} ({vc.level})")
 
-    _commit_tag(args.pyproject, vc.new, args.commit, args.tag)
+    if not args.dry_run:
+        _commit_tag(args.pyproject, vc.new, args.commit, args.tag)
     return 0
 
 
@@ -288,6 +290,11 @@ def main(argv: list[str] | None = None) -> int:
         help="git commit the version change",
     )
     p_bump.add_argument("--tag", action="store_true", help="git tag the new version")
+    p_bump.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show new version without modifying files",
+    )
     p_bump.set_defaults(func=bump_command)
 
     p_auto = sub.add_parser(
@@ -306,6 +313,11 @@ def main(argv: list[str] | None = None) -> int:
         help="git commit the version change",
     )
     p_auto.add_argument("--tag", action="store_true", help="git tag the new version")
+    p_auto.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show new version without modifying files",
+    )
     p_auto.set_defaults(func=auto_command)
 
     args = parser.parse_args(argv)

--- a/semverbump/versioning.py
+++ b/semverbump/versioning.py
@@ -98,13 +98,16 @@ def write_project_version(
 
 
 def apply_bump(
-    level: str, pyproject_path: str | Path = "pyproject.toml"
+    level: str,
+    pyproject_path: str | Path = "pyproject.toml",
+    dry_run: bool = False,
 ) -> VersionChange:
     """Apply a semantic version bump to ``pyproject.toml``.
 
     Args:
         level: Bump level to apply (``"major"``, ``"minor"``, or ``"patch"``).
         pyproject_path: Path to the ``pyproject.toml`` file.
+        dry_run: If ``True``, compute the new version without writing to disk.
 
     Returns:
         :class:`VersionChange` detailing the old and new versions.
@@ -112,5 +115,6 @@ def apply_bump(
 
     old = read_project_version(pyproject_path)
     new = bump_string(old, level)
-    write_project_version(new, pyproject_path)
+    if not dry_run:
+        write_project_version(new, pyproject_path)
     return VersionChange(old=old, new=new, level=level)

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -17,3 +17,11 @@ def test_apply_bump(tmp_path: Path):
     out = apply_bump("minor", py)
     assert out.old == "0.1.0" and out.new == "0.2.0"
     assert read_project_version(py) == "0.2.0"
+
+
+def test_apply_bump_dry_run(tmp_path: Path) -> None:
+    py = tmp_path / "pyproject.toml"
+    py.write_text(toml_dumps({"project": {"version": "1.2.3"}}))
+    out = apply_bump("patch", py, dry_run=True)
+    assert out.old == "1.2.3" and out.new == "1.2.4"
+    assert read_project_version(py) == "1.2.3"


### PR DESCRIPTION
## Summary
- add `dry_run` support to version bumping and skip file writes when enabled
- expose `--dry-run` flag for `bump` and `auto` subcommands
- test that dry-run mode preserves existing project version

## Testing
- `isort semverbump/versioning.py semverbump/cli.py tests/test_versioning.py tests/test_cli_auto.py`
- `black semverbump/versioning.py semverbump/cli.py tests/test_versioning.py tests/test_cli_auto.py`
- `ruff check --fix semverbump/versioning.py semverbump/cli.py tests/test_versioning.py tests/test_cli_auto.py`
- `pytest`

Labels: feat

------
https://chatgpt.com/codex/tasks/task_e_689f1a9055fc8322a04a690e68263306