### PR TITLE
feat(versioning): sync version across configured files

### DIFF
--- a/semverbump/config.py
+++ b/semverbump/config.py
@@ -11,7 +11,12 @@ from pathlib import Path
 from typing import List, Set
 
 _DEFAULTS = {
-    "project": {"package": "", "public_roots": ["."], "index_file": "pyproject.toml"},
+    "project": {
+        "package": "",
+        "public_roots": ["."],
+        "index_file": "pyproject.toml",
+        "version_files": [],
+    },
     "ignore": {"paths": ["tests/**", "examples/**", "scripts/**"]},
     "rules": {"return_type_change": "minor"},  # or "major"
     "analyzers": {"cli": False},
@@ -28,11 +33,21 @@ class Rules:
 
 @dataclass
 class Project:
-    """Project metadata and locations."""
+    """Project metadata and locations.
+
+    Attributes:
+        package: Importable package name whose ``__init__`` module holds
+            ``__version__``.
+        public_roots: Roots to scan for public API extraction.
+        index_file: Path to the ``pyproject.toml`` file.
+        version_files: Additional files containing the project version that
+            should be kept in sync when bumping.
+    """
 
     package: str = ""
     public_roots: List[str] = field(default_factory=lambda: ["."])
     index_file: str = "pyproject.toml"
+    version_files: List[str] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -11,9 +11,31 @@ def test_bump_string():
     assert bump_string("1.2.3", "major") == "2.0.0"
 
 
-def test_apply_bump(tmp_path: Path):
+def test_apply_bump(tmp_path: Path) -> None:
     py = tmp_path / "pyproject.toml"
     py.write_text(toml_dumps({"project": {"version": "0.1.0"}}))
-    out = apply_bump("minor", py)
+
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir()
+    init = pkg / "__init__.py"
+    init.write_text("__version__ = '0.1.0'")
+
+    extra = tmp_path / "setup.py"
+    extra.write_text("version='0.1.0'")
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    conf = docs / "conf.py"
+    conf.write_text("release = '0.1.0'")
+
+    out = apply_bump(
+        "minor",
+        py,
+        package="mypkg",
+        extra_files=[extra, conf],
+    )
+
     assert out.old == "0.1.0" and out.new == "0.2.0"
     assert read_project_version(py) == "0.2.0"
+    for f in (init, extra, conf):
+        assert "0.2.0" in f.read_text()


### PR DESCRIPTION
## Summary
- update `apply_bump` to write new version to package `__init__` and extra configured files
- allow configuring additional version files in `semverbump.toml`
- test that bumps propagate to all registered files

## Testing
- `isort --profile black semverbump/cli.py semverbump/config.py semverbump/versioning.py tests/test_versioning.py`
- `black semverbump/cli.py semverbump/config.py semverbump/versioning.py tests/test_versioning.py`
- `ruff check semverbump/cli.py semverbump/config.py semverbump/versioning.py tests/test_versioning.py`
- `pytest`

## Labels
- feat

------
https://chatgpt.com/codex/tasks/task_e_689f1a91005c8322ab8f42c6841a0e6c