### PR TITLE
feat(versioning): support configurable version sources

### DIFF
--- a/semverbump/cli.py
+++ b/semverbump/cli.py
@@ -169,12 +169,12 @@ def bump_command(args: argparse.Namespace) -> int:
         Process exit code.
     """
 
+    cfg = load_config(args.config)
     # If level not provided, compute from base/head
     level = args.level
     base = args.base or _infer_base_ref()
     head = args.head
     if not level:
-        cfg = load_config(args.config)
         old_api = _build_api_at_ref(base, cfg.project.public_roots, cfg.ignore.paths)
         new_api = _build_api_at_ref(head, cfg.project.public_roots, cfg.ignore.paths)
         impacts = diff_public_api(
@@ -183,7 +183,11 @@ def bump_command(args: argparse.Namespace) -> int:
         impacts.extend(_run_analyzers(base, head, cfg))
         level = decide_bump(impacts)
 
-    vc = apply_bump(level, pyproject_path=args.pyproject)
+    vc = apply_bump(
+        level,
+        pyproject_path=args.pyproject,
+        source=cfg.project.version_source,
+    )
     print(f"Bumped version: {vc.old} -> {vc.new} ({vc.level})")
     _commit_tag(args.pyproject, vc.new, args.commit, args.tag)
     return 0
@@ -209,7 +213,11 @@ def auto_command(args: argparse.Namespace) -> int:
     )
     impacts.extend(_run_analyzers(base, head, cfg))
     level = decide_bump(impacts)
-    vc = apply_bump(level, pyproject_path=args.pyproject)
+    vc = apply_bump(
+        level,
+        pyproject_path=args.pyproject,
+        source=cfg.project.version_source,
+    )
 
     if args.format == "json":
         print(

--- a/semverbump/config.py
+++ b/semverbump/config.py
@@ -11,7 +11,12 @@ from pathlib import Path
 from typing import List, Set
 
 _DEFAULTS = {
-    "project": {"package": "", "public_roots": ["."], "index_file": "pyproject.toml"},
+    "project": {
+        "package": "",
+        "public_roots": ["."],
+        "index_file": "pyproject.toml",
+        "version_source": "project",
+    },
     "ignore": {"paths": ["tests/**", "examples/**", "scripts/**"]},
     "rules": {"return_type_change": "minor"},  # or "major"
     "analyzers": {"cli": False},
@@ -28,11 +33,19 @@ class Rules:
 
 @dataclass
 class Project:
-    """Project metadata and locations."""
+    """Project metadata and locations.
+
+    Attributes:
+        package: Name of the top-level Python package.
+        public_roots: Roots to scan for public API extraction.
+        index_file: Path to the project metadata file.
+        version_source: Metadata table holding the version string.
+    """
 
     package: str = ""
     public_roots: List[str] = field(default_factory=lambda: ["."])
     index_file: str = "pyproject.toml"
+    version_source: str = "project"
 
 
 @dataclass

--- a/semverbump/versioning.py
+++ b/semverbump/versioning.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 try:  # pragma: no cover - needed for linting when dependency missing
     from packaging.version import Version
@@ -56,61 +57,112 @@ def bump_string(v: str, level: str) -> str:
     return f"{parts[0]}.{parts[1]}.{parts[2]}"
 
 
-def read_project_version(pyproject_path: str | Path = "pyproject.toml") -> str:
+def read_project_version(
+    pyproject_path: str | Path = "pyproject.toml",
+    source: Literal["project", "tool.poetry"] = "project",
+) -> str:
     """Read the project version from a ``pyproject.toml`` file.
 
     Args:
         pyproject_path: Path to the ``pyproject.toml`` file.
+        source: Metadata table to read the version from.
 
     Returns:
         Project version string.
 
     Raises:
-        KeyError: If the version field is missing.
+        KeyError: If the version field is missing or unsupported.
+        ValueError: If ``source`` is unknown.
     """
 
     data = toml_parse(Path(pyproject_path).read_text(encoding="utf-8"))
-    try:
-        return str(data["project"]["version"])
-    except Exception as e:  # pragma: no cover - explicit re-raise for clarity
-        raise KeyError("project.version not found in pyproject.toml") from e
+
+    if source == "project":
+        proj = data.get("project", {})
+        v = proj.get("version")
+        if isinstance(v, dict) and "attr" in v:
+            raise KeyError("project.version uses attr; unsupported")
+        if "dynamic" in proj and "version" in proj.get("dynamic", []):
+            raise KeyError("project.version declared dynamic; unsupported")
+        if v is not None:
+            return str(v)
+        if data.get("tool", {}).get("poetry", {}).get("version"):
+            raise KeyError("use source='tool.poetry' for poetry-managed version")
+        raise KeyError("project.version not found in pyproject.toml")
+
+    if source == "tool.poetry":
+        poetry = data.get("tool", {}).get("poetry", {})
+        v = poetry.get("version")
+        if v is not None:
+            return str(v)
+        proj = data.get("project", {})
+        if isinstance(proj.get("version"), dict) and "attr" in proj["version"]:
+            raise KeyError("project.version uses attr; unsupported")
+        if "dynamic" in proj and "version" in proj.get("dynamic", []):
+            raise KeyError("project.version declared dynamic; unsupported")
+        if proj.get("version"):
+            raise KeyError("use source='project' for project.version")
+        raise KeyError("tool.poetry.version not found in pyproject.toml")
+
+    raise ValueError(f"Unknown source {source}")
 
 
 def write_project_version(
-    new_version: str, pyproject_path: str | Path = "pyproject.toml"
+    new_version: str,
+    pyproject_path: str | Path = "pyproject.toml",
+    source: Literal["project", "tool.poetry"] = "project",
 ) -> None:
     """Write ``new_version`` to the ``pyproject.toml`` file.
 
     Args:
         new_version: Version string to write.
         pyproject_path: Path to the ``pyproject.toml`` file.
+        source: Metadata table to update.
 
     Raises:
-        KeyError: If the ``[project]`` table is missing from the file.
+        KeyError: If the table is missing or version is unsupported.
+        ValueError: If ``source`` is unknown.
     """
 
     p = Path(pyproject_path)
     data = toml_parse(p.read_text(encoding="utf-8"))
-    if "project" not in data:
-        raise KeyError("No [project] table in pyproject.toml")
-    data["project"]["version"] = new_version
+    if source == "project":
+        if "project" not in data:
+            raise KeyError("No [project] table in pyproject.toml")
+        proj = data["project"]
+        if isinstance(proj.get("version"), dict) and "attr" in proj["version"]:
+            raise KeyError("project.version uses attr; unsupported")
+        if "dynamic" in proj and "version" in proj.get("dynamic", []):
+            raise KeyError("project.version declared dynamic; unsupported")
+        proj["version"] = new_version
+    elif source == "tool.poetry":
+        tool = data.setdefault("tool", {})
+        poetry = tool.get("poetry")
+        if poetry is None:
+            raise KeyError("No [tool.poetry] table in pyproject.toml")
+        poetry["version"] = new_version
+    else:
+        raise ValueError(f"Unknown source {source}")
     p.write_text(toml_dumps(data), encoding="utf-8")
 
 
 def apply_bump(
-    level: str, pyproject_path: str | Path = "pyproject.toml"
+    level: str,
+    pyproject_path: str | Path = "pyproject.toml",
+    source: Literal["project", "tool.poetry"] = "project",
 ) -> VersionChange:
     """Apply a semantic version bump to ``pyproject.toml``.
 
     Args:
         level: Bump level to apply (``"major"``, ``"minor"``, or ``"patch"``).
         pyproject_path: Path to the ``pyproject.toml`` file.
+        source: Metadata table holding the version.
 
     Returns:
         :class:`VersionChange` detailing the old and new versions.
     """
 
-    old = read_project_version(pyproject_path)
+    old = read_project_version(pyproject_path, source=source)
     new = bump_string(old, level)
-    write_project_version(new, pyproject_path)
+    write_project_version(new, pyproject_path, source=source)
     return VersionChange(old=old, new=new, level=level)

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from tomlkit import dumps as toml_dumps
 
 from semverbump.versioning import apply_bump, bump_string, read_project_version
@@ -17,3 +18,25 @@ def test_apply_bump(tmp_path: Path):
     out = apply_bump("minor", py)
     assert out.old == "0.1.0" and out.new == "0.2.0"
     assert read_project_version(py) == "0.2.0"
+
+
+def test_apply_bump_poetry(tmp_path: Path):
+    py = tmp_path / "pyproject.toml"
+    py.write_text(toml_dumps({"tool": {"poetry": {"version": "1.0.0"}}}))
+    out = apply_bump("patch", py, source="tool.poetry")
+    assert out.old == "1.0.0" and out.new == "1.0.1"
+    assert read_project_version(py, source="tool.poetry") == "1.0.1"
+
+
+def test_read_project_version_dynamic(tmp_path: Path):
+    py = tmp_path / "pyproject.toml"
+    py.write_text(toml_dumps({"project": {"dynamic": ["version"]}}))
+    with pytest.raises(KeyError):
+        read_project_version(py)
+
+
+def test_read_project_version_attr(tmp_path: Path):
+    py = tmp_path / "pyproject.toml"
+    py.write_text(toml_dumps({"project": {"version": {"attr": "pkg.__version__"}}}))
+    with pytest.raises(KeyError):
+        read_project_version(py)


### PR DESCRIPTION
## Summary
- support reading/writing package version from either `[project]` or `tool.poetry`
- allow selecting version metadata source via `version_source` config option
- detect dynamic and attribute-based versions before bumping

## Testing
- `python -m isort .`
- `python -m black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f1a91f27083229f6f40d8de48324a