### PR TITLE
feat(versioning): update version across multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ recommending the next semantic version. It can even apply the bump for you.
 - Static diff of the public API to highlight breaking changes.
 - Pluggable analysers for command-line tools, web routes and database
   migrations.
-- Optional helpers to update ``pyproject.toml`` and tag the release.
+- Optional helpers to update version numbers across common files and tag the release.
 
 ## Installation
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -15,6 +15,14 @@ Exclude paths from API scanning:
    [ignore]
    paths = ["tests/**", "examples/**"]
 
+Specify additional version file locations:
+
+.. code-block:: toml
+
+   [version]
+   paths = ["pyproject.toml", "setup.py", "src/pkg/__init__.py"]
+   ignore = ["examples/**"]
+
 Apply a bump and commit/tag automatically:
 
 .. code-block:: console

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -32,6 +32,11 @@ Once the level is known, apply it directly to ``pyproject.toml``:
 This prints the old and new versions and, with the flags above, commits and tags
 the change.
 
+By default, the command updates common version locations such as
+``setup.py``, ``setup.cfg`` and any ``__version__`` variables in Python modules.
+Use ``--version-path`` to target specific files and ``--version-ignore`` to
+exclude paths from updating.
+
 If ``--level`` is omitted, provide ``--base`` and ``--head`` and the command
 will automatically decide in the same fashion as ``decide``.
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -25,3 +25,38 @@ def test_apply_bump_dry_run(tmp_path: Path) -> None:
     out = apply_bump("patch", py, dry_run=True)
     assert out.old == "1.2.3" and out.new == "1.2.4"
     assert read_project_version(py) == "1.2.3"
+
+
+def test_apply_bump_updates_extra_files(tmp_path: Path) -> None:
+    py = tmp_path / "pyproject.toml"
+    py.write_text(toml_dumps({"project": {"version": "0.1.0"}}))
+    setup = tmp_path / "setup.py"
+    setup.write_text("version='0.1.0'", encoding="utf-8")
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    init = pkg / "__init__.py"
+    init.write_text("__version__ = '0.1.0'", encoding="utf-8")
+
+    out = apply_bump(
+        "patch",
+        py,
+        paths=[str(py), str(setup), str(init)],
+    )
+    assert out.new == "0.1.1"
+    assert "version='0.1.1'" in setup.read_text(encoding="utf-8")
+    assert "__version__ = '0.1.1'" in init.read_text(encoding="utf-8")
+
+
+def test_apply_bump_ignore_patterns(tmp_path: Path) -> None:
+    py = tmp_path / "pyproject.toml"
+    py.write_text(toml_dumps({"project": {"version": "1.0.0"}}))
+    other = tmp_path / "other.py"
+    other.write_text("__version__ = '1.0.0'", encoding="utf-8")
+
+    apply_bump(
+        "minor",
+        py,
+        paths=[str(py), str(other)],
+        ignore=[str(other)],
+    )
+    assert "__version__ = '1.0.0'" in other.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- allow version bumps to update multiple file types and __version__ variables
- add configuration and CLI options to specify or ignore version locations
- document customizable version paths

## Testing
- `ruff check .`
- `isort semverbump/config.py semverbump/versioning.py semverbump/cli.py tests/test_versioning.py`
- `black semverbump/config.py semverbump/versioning.py semverbump/cli.py tests/test_versioning.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f1fc1b2108322aac738be47b40ecc