### PR TITLE
fix(cli): improve help output and prevent tuple error

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,51 +1,114 @@
 Usage
 =====
 
-Suggesting a bump
------------------
+The ``semverbump`` command-line interface provides three subcommands to help
+manage project versions based on public API changes. This section explains each
+command, its arguments, and expected outputs.
 
-To discover the next semantic version between two git references, run:
+Global options
+--------------
+
+``--config``
+    Path to the configuration file. Defaults to ``semverbump.toml`` in the
+    current working directory.
+
+``decide`` – suggest a bump
+---------------------------
+
+Compare two git references and report the semantic version level they require.
+
+**Arguments**
+
+``--base BASE``
+    Base git reference to compare against, for example ``origin/main``.
+    Required.
+
+``--head HEAD``
+    Head git reference. Defaults to ``HEAD``.
+
+``--format {text,md,json}``
+    Output style. ``text`` prints plain console output, ``md`` emits Markdown,
+    and ``json`` produces machine-readable data. Defaults to ``text``.
+
+**Example**
 
 .. code-block:: console
 
-   semverbump decide --base origin/main --head HEAD --format text
-
-Example output:
+   semverbump decide --base origin/main --head HEAD --format md
 
 .. code-block:: text
 
-   Suggested bump: minor
+   **semverbump** suggests: `minor`
    - [MINOR] cli.new_command: added CLI entry 'greet'
 
-Set ``--format md`` for Markdown or ``--format json`` for machine-readable
-results.
+``bump`` – apply a bump
+-----------------------
 
-Applying a bump
----------------
+Update version information in ``pyproject.toml`` and other files.
 
-Once the level is known, apply it directly to ``pyproject.toml``:
+**Arguments**
+
+``--level {major,minor,patch}``
+    Desired bump level. If omitted, ``--base`` and ``--head`` are used to
+    determine the level automatically.
+
+``--base BASE``
+    Base git reference when auto-deciding the level. Defaults to the current
+    branch's upstream.
+
+``--head HEAD``
+    Head git reference. Defaults to ``HEAD``.
+
+``--pyproject PATH``
+    Path to the project's ``pyproject.toml`` file. Defaults to
+    ``pyproject.toml``.
+
+``--version-path GLOB``
+    Glob pattern for files that contain the project version. May be repeated to
+    update multiple locations.
+
+``--version-ignore GLOB``
+    Glob pattern for paths to exclude from version updates.
+
+``--commit``
+    Create a git commit for the version change.
+
+``--tag``
+    Create a git tag for the new version.
+
+``--dry-run``
+    Display the new version without modifying any files.
+
+**Example**
 
 .. code-block:: console
 
    semverbump bump --level minor --pyproject pyproject.toml --commit --tag
 
-This prints the old and new versions and, with the flags above, commits and tags
-the change.
+This prints the old and new versions and, when ``--commit`` and ``--tag`` are
+set, commits and tags the release.
 
-By default, the command updates common version locations such as
-``setup.py``, ``setup.cfg`` and any ``__version__`` variables in Python modules.
-Use ``--version-path`` to target specific files and ``--version-ignore`` to
-exclude paths from updating.
+``auto`` – decide and bump
+----------------------------
 
-If ``--level`` is omitted, provide ``--base`` and ``--head`` and the command
-will automatically decide in the same fashion as ``decide``.
+Combine ``decide`` and ``bump`` to infer the level and update files in one
+command. When ``--base`` is omitted, the current branch's upstream is used.
 
-Automatic bump
---------------
+Supported arguments mirror those of ``decide`` and ``bump``:
 
-To decide and apply the bump in a single step, use the ``auto`` command. When
-``--base`` is omitted, the current branch's upstream is used as the comparison
-reference.
+``--base``
+    Base git reference. Defaults to the upstream of the current branch.
+
+``--head``
+    Head git reference. Defaults to ``HEAD``.
+
+``--format``
+    Output style, as in ``decide``.
+
+``--pyproject``, ``--version-path``, ``--version-ignore``, ``--commit``, ``--tag``, ``--dry-run``
+    Behave the same as in ``bump``.
+
+**Example**
 
 .. code-block:: console
 
@@ -64,5 +127,5 @@ A typical release sequence might look like this:
    semverbump auto --commit --tag
    git push --follow-tags origin HEAD
 
-Both commands read configuration from ``semverbump.toml`` by default. Use
+All commands read configuration from ``semverbump.toml`` by default. Use
 ``--config`` to specify an alternate file.

--- a/semverbump/cli.py
+++ b/semverbump/cli.py
@@ -268,95 +268,142 @@ def main(argv: list[str] | None = None) -> int:
     avail = ", ".join(available()) or "none"
     parser = argparse.ArgumentParser(
         prog="semverbump",
-        description=(
-            f"Suggest and apply semantic version bumps. Available analyzers: {avail}.",
-        ),
+        description=f"Suggest and apply semantic version bumps. Available analyzers: {avail}.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "--config",
         default="semverbump.toml",
-        help="Path to config (default: semverbump.toml)",
+        help="Path to configuration file.",
     )
 
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    p_decide = sub.add_parser("decide", help="Suggest bump between two refs")
-    p_decide.add_argument(
-        "--base", required=True, help="Base ref (e.g., origin/master)"
+    p_decide = sub.add_parser(
+        "decide",
+        help="Suggest bump between two refs",
+        description="Compare two git references and report the required semantic version bump.",
     )
-    p_decide.add_argument("--head", default="HEAD", help="Head ref (default: HEAD)")
-    p_decide.add_argument("--format", choices=["text", "md", "json"], default="text")
+    p_decide.add_argument(
+        "--base",
+        required=True,
+        help="Base git reference to compare against (for example 'origin/main').",
+    )
+    p_decide.add_argument(
+        "--head",
+        default="HEAD",
+        help="Head git reference; defaults to the current HEAD.",
+    )
+    p_decide.add_argument(
+        "--format",
+        choices=["text", "md", "json"],
+        default="text",
+        help="Output style: plain text, Markdown, or machine-readable JSON.",
+    )
     p_decide.set_defaults(func=decide_command)
 
-    p_bump = sub.add_parser("bump", help="Apply a bump to pyproject.toml")
+    p_bump = sub.add_parser(
+        "bump",
+        help="Apply a bump to pyproject.toml",
+        description="Update project version metadata and optionally commit and tag the change.",
+    )
     p_bump.add_argument(
         "--level",
         choices=["major", "minor", "patch"],
-        help="Bump level; if omitted, auto-decide from refs",
+        help="Desired bump level; if omitted, it is inferred from --base and --head.",
     )
     p_bump.add_argument(
         "--base",
-        help="Base ref (defaults to upstream of HEAD when --level omitted)",
+        help="Base git reference when auto-deciding the level (uses upstream of HEAD by default).",
     )
-    p_bump.add_argument("--head", default="HEAD", help="Head ref (default: HEAD)")
-    p_bump.add_argument("--pyproject", default="pyproject.toml")
+    p_bump.add_argument(
+        "--head",
+        default="HEAD",
+        help="Head git reference; defaults to the current HEAD.",
+    )
+    p_bump.add_argument(
+        "--pyproject",
+        default="pyproject.toml",
+        help="Path to the project's pyproject.toml file.",
+    )
     p_bump.add_argument(
         "--version-path",
         action="append",
         dest="version_path",
-        help="Glob of files containing the project version (repeatable)",
+        help="Glob pattern for files that contain the project version (repeatable).",
     )
     p_bump.add_argument(
         "--version-ignore",
         action="append",
         dest="version_ignore",
-        help="Glob of paths to ignore when updating version",
+        help="Glob pattern for paths to exclude from version updates.",
     )
     p_bump.add_argument(
         "--commit",
         action="store_true",
-        help="git commit the version change",
+        help="Create a git commit for the version change.",
     )
-    p_bump.add_argument("--tag", action="store_true", help="git tag the new version")
+    p_bump.add_argument(
+        "--tag", action="store_true", help="Create a git tag for the new version."
+    )
     p_bump.add_argument(
         "--dry-run",
         action="store_true",
-        help="show new version without modifying files",
+        help="Display the new version without modifying any files.",
     )
     p_bump.set_defaults(func=bump_command)
 
     p_auto = sub.add_parser(
-        "auto", help="Decide and apply bump, committing and tagging optionally"
+        "auto",
+        help="Decide and apply bump, committing and tagging optionally",
+        description=(
+            "Combine 'decide' and 'bump' to infer the level and update files in one step."
+        ),
     )
     p_auto.add_argument(
         "--base",
-        help="Base ref (defaults to upstream of HEAD)",
+        help="Base git reference; defaults to the upstream of the current branch.",
     )
-    p_auto.add_argument("--head", default="HEAD", help="Head ref (default: HEAD)")
-    p_auto.add_argument("--format", choices=["text", "md", "json"], default="text")
-    p_auto.add_argument("--pyproject", default="pyproject.toml")
+    p_auto.add_argument(
+        "--head",
+        default="HEAD",
+        help="Head git reference; defaults to the current HEAD.",
+    )
+    p_auto.add_argument(
+        "--format",
+        choices=["text", "md", "json"],
+        default="text",
+        help="Output style: plain text, Markdown, or machine-readable JSON.",
+    )
+    p_auto.add_argument(
+        "--pyproject",
+        default="pyproject.toml",
+        help="Path to the project's pyproject.toml file.",
+    )
     p_auto.add_argument(
         "--version-path",
         action="append",
         dest="version_path",
-        help="Glob of files containing the project version (repeatable)",
+        help="Glob pattern for files that contain the project version (repeatable).",
     )
     p_auto.add_argument(
         "--version-ignore",
         action="append",
         dest="version_ignore",
-        help="Glob of paths to ignore when updating version",
+        help="Glob pattern for paths to exclude from version updates.",
     )
     p_auto.add_argument(
         "--commit",
         action="store_true",
-        help="git commit the version change",
+        help="Create a git commit for the version change.",
     )
-    p_auto.add_argument("--tag", action="store_true", help="git tag the new version")
+    p_auto.add_argument(
+        "--tag", action="store_true", help="Create a git tag for the new version."
+    )
     p_auto.add_argument(
         "--dry-run",
         action="store_true",
-        help="show new version without modifying files",
+        help="Display the new version without modifying any files.",
     )
     p_auto.set_defaults(func=auto_command)
 


### PR DESCRIPTION
## Summary
- fix CLI `--help` failure and expand option descriptions
- document `decide`, `bump`, and `auto` commands with detailed arguments and examples

## Testing
- `ruff check --fix semverbump/cli.py`
- `isort semverbump/cli.py`
- `black semverbump/cli.py`
- `ruff check .`
- `pytest`
- `sphinx-build -b html docs docs/_build`


------
https://chatgpt.com/codex/tasks/task_e_689f2164b3d48322bbd6703c62608394