### PR TITLE
docs(bump): warn about repeated version increments

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -5,3 +5,5 @@ Troubleshooting
   ``semverbump.toml`` and required dependencies are installed.
 - **Configuration not found**: pass ``--config`` to specify the file location.
 - **Git errors**: run commands inside a git repository with accessible refs.
+- **Version keeps incrementing**: commit or revert the version change before
+  rerunning, or use ``--dry-run`` to preview.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -76,6 +76,10 @@ Update version information in ``pyproject.toml`` and other files.
 ``--commit``
     Create a git commit for the version change.
 
+    .. note::
+        The version will bump on every invocation unless the change is
+        committed or reverted.
+
 ``--tag``
     Create a git tag for the new version.
 


### PR DESCRIPTION
## Summary
- warn users about repeated version bumps if changes remain uncommitted
- add troubleshooting note for accidental incremental bumps

## Testing
- `python -m isort .`
- `python -m black . --check`
- `ruff check .` *(fails: F821 Undefined name `find_pyproject`)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'tomlkit')*


------
https://chatgpt.com/codex/tasks/task_e_689f2d82ca5c8322a498c475c6b70e10